### PR TITLE
Re-enabling gaia-dialog integration tests. Moving travis node version…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ env:
   matrix:
     - CI_ACTION="npm run test-lint"
     - CI_ACTION="npm run test-unit"
-    # - CI_ACTION="npm run test-integration"
+    - CI_ACTION="npm run test-integration"

--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ Include folowing files in HTML
 ## Tests
 
 1. Ensure Firefox Nightly is installed on your machine. (Visit: [Firefox Nightly Page](https://nightly.mozilla.org/))
-2. `$ npm install`
-3. `$ npm run test-unit`
+2. To run unit tests you need npm >= 3 installed.
+3. `$ npm install`
+4. `$ npm run test-unit`
 
 If you would like tests to run on file change use:
 

--- a/package.json
+++ b/package.json
@@ -12,20 +12,22 @@
     "karma-chai-sinon": "^0.1.5",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.2.1",
+    "marionette-client": "1.9.4",
     "marionette-firefox-host": "1.0.4",
     "marionette-helper": "0.3.2",
     "marionette-js-runner": "1.1.3",
     "mozilla-download": "^1.1.1",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0",
-    "test-utils": "git://github.com/fxos-components/test-utils.git#v0.0.4"
+    "test-utils": "fxos-components/test-utils"
   },
   "scripts": {
     "postinstall": "bower install",
     "test-lint": "./node_modules/jshint/bin/jshint gaia-dialog*.js",
     "test-unit": "./node_modules/karma/bin/karma start test/karma.conf.js --single-run",
     "test-integration": "./node_modules/.bin/marionette-mocha --reporter spec --host marionette-firefox-host --runtime $FIREFOX_NIGHTLY_BIN --timeout 6000s test/test-integration.js",
-    "test-unit-dev": "./node_modules/karma/bin/karma start test/karma.conf.js"
+    "test-unit-dev": "./node_modules/karma/bin/karma start test/karma.conf.js",
+    "test": "npm run test-lint && npm run test-unit && npm run test-integration"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
… back to 4.2.2 (LTS) to avoid conflicts with gaia.
